### PR TITLE
Add support for Arch-based distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,6 +188,13 @@ install_packages() {
             read_packagelist "packagelists/fedora.packages" | xargs sudo dnf install -y || log_warning "Some dnf installs may have failed"
           fi
           ;;
+        arch | endeavouros | cachyos | garuda)
+          if [ -f "packagelists/pacman.packages" ]; then
+            check_command pacman
+            log_info "Installing Pacman packages..."
+            read_packagelist "packagelists/pacman.packages" | xargs -r sudo pacman -S --noconfirm --needed || log_warning "Some pacman installs may have failed"
+          fi
+          ;;
         *)
           log_warning "Unsupported Linux distribution: $DISTRO_ID"
           ;;

--- a/packagelists/pacman.packages
+++ b/packagelists/pacman.packages
@@ -1,0 +1,25 @@
+# Pacman package list for Arch-based distributions
+# Format: one package name per line
+# Lines starting with # are comments and will be ignored
+
+# Terminal utilities
+zsh
+fzf
+tmux
+lsd
+fastfetch
+ripgrep
+fd
+bat
+
+# Development tools
+git
+neovim
+python
+gcc
+make
+
+# Networking tools
+curl
+wget
+nmap

--- a/update.sh
+++ b/update.sh
@@ -35,6 +35,12 @@ function update_all() {
             sudo dnf upgrade -y || log_warning "DNF update failed"
           fi
           ;;
+        arch | endeavouros | cachyos | garuda)
+          if command -v pacman &>/dev/null; then
+            log_info "Updating Pacman..."
+            sudo pacman -Syu --noconfirm || log_warning "Pacman update failed"
+          fi
+          ;;
       esac
       ;;
   esac


### PR DESCRIPTION
## Summary
- add pacman package list for Arch-based distributions
- install pacman packages when running on Arch/EndeavourOS/CachyOS/Garuda
- update pacman packages in the update script

## Testing
- `git diff --name-only --cached`


------
https://chatgpt.com/codex/tasks/task_e_684661f54f788324b991add1f5c676b6