### PR TITLE
Fix symlink space bug

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -283,13 +283,14 @@ setup_dotfiles() {
       ;;
   esac
 
-  symlink_pairs="
+  symlink_pairs="$(cat <<'EOF'
 # Format: source|destination
-  nvim/config|${HOME}/.config/nvim
-  tmux/.tmux.conf.local|${HOME}/.tmux.conf.local
-  ${ZSHRC_SOURCE}|${HOME}/.zshrc
-  ${OS_SPECIFIC_SYMLINKS}
-"
+nvim/config|${HOME}/.config/nvim
+tmux/.tmux.conf.local|${HOME}/.tmux.conf.local
+${ZSHRC_SOURCE}|${HOME}/.zshrc
+${OS_SPECIFIC_SYMLINKS}
+EOF
+)"
 
   echo "${symlink_pairs}" | grep -v "^#" | grep -v "^$" | while IFS="|" read -r src dst; do
     # Skip empty lines


### PR DESCRIPTION
## Summary
- fix extra spaces when building symlink pairs

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68468e5f421883249e68774c466baa2f