### PR TITLE
Fix symlink pair heredoc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -301,7 +301,7 @@ setup_dotfiles() {
       ;;
   esac
 
-  symlink_pairs="$(cat <<'EOF'
+  symlink_pairs="$(cat <<EOF
 # Format: source|destination
 nvim/config|${HOME}/.config/nvim
 tmux/.tmux.conf.local|${HOME}/.tmux.conf.local


### PR DESCRIPTION
## Summary
- ensure variables expand correctly when building symlink list in install.sh

## Testing
- `DEBUG=true BYPASS_VERIFY_ESSENTIALS=true BYPASS_GIT_REPOS=true BYPASS_OS_PACKAGES=true BYPASS_CARGO=true BYPASS_NPM=true BYPASS_MACOS_DEFAULTS=true ./install.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847100a26e88324819c85de4406cacb