### PR TITLE
Remove leftover hammerspoon symlink

### DIFF
--- a/hammerspoon/hammerspoon
+++ b/hammerspoon/hammerspoon
@@ -1,1 +1,0 @@
-/Users/erica/dotfiles/hammerspoon


### PR DESCRIPTION
## Summary
- drop the obsolete `hammerspoon/hammerspoon` symlink

## Testing
- `PATH=/tmp/fakebin:$PATH env HOME=/tmp/home1 OS=macos BYPASS_VERIFY_ESSENTIALS=true BYPASS_GIT_REPOS=true BYPASS_OS_PACKAGES=true BYPASS_CARGO=true BYPASS_NPM=true BYPASS_MACOS_DEFAULTS=true bash ./install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847154781bc8324a81719386e564dcc