### PR TITLE
Add gitconfig and link it in install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ ssh/config         # if you accidentally create a real config here
 # Editor-specific junk
 .vscode/
 *.log
+# Git credentials and local overrides
+.git-credentials
+git/gitconfig.local

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ Available flags include `BYPASS_VERIFY_ESSENTIALS`, `BYPASS_GIT_REPOS`,
 `BYPASS_MACOS_DEFAULTS` and `BYPASS_OS_UPDATES`. Setting `DEBUG=true` will
 enable verbose logging.
 
+### Git configuration
+
+A global `.gitconfig` lives in `git/gitconfig`. It stores only non-sensitive
+defaults such as your name and email. If you need machine-specific settings or
+credentials, create `~/.gitconfig.local`; it will be loaded automatically but is
+ignored by version control.
+

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -1,0 +1,7 @@
+[user]
+    name = Erica Young
+    email = erica@pomme.cafe
+
+# Load additional settings like credentials from ~/.gitconfig.local if present
+[include]
+    path = ~/.gitconfig.local

--- a/install.sh
+++ b/install.sh
@@ -306,6 +306,7 @@ setup_dotfiles() {
 nvim/config|${HOME}/.config/nvim
 tmux/.tmux.conf.local|${HOME}/.tmux.conf.local
 ${ZSHRC_SOURCE}|${HOME}/.zshrc
+git/gitconfig|${HOME}/.gitconfig
 ${OS_SPECIFIC_SYMLINKS}
 EOF
 )"


### PR DESCRIPTION
## Summary
- add `git/gitconfig` with user info
- link the gitconfig from `install.sh`
- allow an optional `~/.gitconfig.local`
- ignore credential files

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850bc710ab08324808ca0c812ee0c99