### PR TITLE
Add centralized util.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ These scripts install a minimal environment by linking configuration files and i
 - macOS (Homebrew)
 - Debian/Ubuntu (apt)
 - Fedora (dnf)
-- Arch-based (pacman)
+- Arch-based (pacman) — includes Manjaro, EndeavourOS, CachyOS, Garuda, etc.
 - **NixOS** (nix-env)
 
 NixOS support is intentionally lightweight. If you manage packages declaratively, you can skip running the package installation step.
+
+Common OS detection logic lives in `util.sh`. It exposes functions such as
+`detect_os`, `detect_linux_distro`, and helper predicates like
+`is_arch_based` or `is_debian_based` that other scripts source to tailor
+behavior for each distribution family.
 
 ## Usage
 

--- a/shell/zshrc_linux
+++ b/shell/zshrc_linux
@@ -50,25 +50,23 @@ source "$HOME/dotfiles/shell/alias_dots.zsh"
 source "$HOME/dotfiles/shell/alias_tar.zsh"
 
 # distro package shortcuts
-if [[ -f /etc/os-release ]]; then
-    . /etc/os-release
-    case "$ID" in
-    fedora)
+source "$HOME/dotfiles/util.sh"
+detect_os
+if [[ $OS == linux ]]; then
+    detect_linux_distro
+    if is_fedora_based; then
         alias update='sudo dnf update'
         alias install='sudo dnf install'
         alias search='dnf search'
-        ;;
-    ubuntu | debian)
+    elif is_debian_based; then
         alias update='sudo apt update && sudo apt upgrade'
         alias install='sudo apt install'
         alias search='apt search'
-        ;;
-    arch | manjaro)
+    elif is_arch_based; then
         alias update='sudo pacman -Syu'
         alias install='sudo pacman -S'
         alias search='pacman -Ss'
-        ;;
-    esac
+    fi
 fi
 
 # Nicer versions of common commands

--- a/util.sh
+++ b/util.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Default bypass flags shared by the helper scripts
+: "${BYPASS_VERIFY_ESSENTIALS:=false}"
+: "${BYPASS_GIT_REPOS:=false}"
+: "${BYPASS_OS_PACKAGES:=false}"
+: "${BYPASS_CARGO:=false}"
+: "${BYPASS_NPM:=false}"
+: "${BYPASS_SETUP_DOTFILES:=false}"
+: "${BYPASS_MACOS_DEFAULTS:=false}"
+: "${BYPASS_OS_UPDATES:=false}"
+
+# Logging helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+GREY='\033[0;37m'
+MAGENTA='\033[0;35m'
+RESET='\033[0m'
+
+log_info() {
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S') ${CYAN}[INFO]${RESET} $1"
+}
+
+log_debug() {
+    if [ "${DEBUG:-false}" = true ]; then
+        echo -e "$(date '+%Y-%m-%d %H:%M:%S') ${BLUE}[DEBUG]${RESET} $1" >&2
+    fi
+}
+
+log_success() {
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S') ${GREEN}[SUCCESS]${RESET} $1"
+}
+
+log_warning() {
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S') ${YELLOW}[WARNING]${RESET} $1"
+}
+
+log_error() {
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S') ${RED}[ERROR]${RESET} $1" >&2
+}
+
+log_critical() {
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S') ${MAGENTA}[CRITICAL]${RESET} $1" >&2
+    exit 1
+}
+
+join_args() {
+    joined=""
+    for arg in "$@"; do
+        joined="$joined$arg, "
+    done
+    echo "${joined%, }"
+}
+
+# Detect the operating system
+# Sets global OS variable to linux, macos or unknown
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux*) OS="linux" ;;
+        Darwin*) OS="macos" ;;
+        *) OS="unknown" ;;
+    esac
+    echo "$OS"
+}
+
+# Detect the Linux distribution via /etc/os-release
+# Sets global DISTRO_ID
+
+detect_linux_distro() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO_ID="${ID,,}"
+    else
+        DISTRO_ID="unknown"
+    fi
+    echo "$DISTRO_ID"
+}
+
+# Map $DISTRO_ID to a higher level family name
+# Result stored in DISTRO_FAMILY and also echoed
+
+distro_family() {
+    [ -z "${DISTRO_ID:-}" ] && detect_linux_distro >/dev/null
+    case "$DISTRO_ID" in
+        ubuntu|debian)
+            DISTRO_FAMILY="debian"
+            ;;
+        fedora)
+            DISTRO_FAMILY="fedora"
+            ;;
+        arch|manjaro|endeavouros|cachyos|garuda)
+            DISTRO_FAMILY="arch"
+            ;;
+        nixos)
+            DISTRO_FAMILY="nixos"
+            ;;
+        *)
+            DISTRO_FAMILY="unknown"
+            ;;
+    esac
+    echo "$DISTRO_FAMILY"
+}
+
+is_arch_based() { [ "$(distro_family)" = "arch" ]; }
+
+is_debian_based() { [ "$(distro_family)" = "debian" ]; }
+
+is_fedora_based() { [ "$(distro_family)" = "fedora" ]; }
+
+is_nixos() { [ "$(distro_family)" = "nixos" ]; }
+


### PR DESCRIPTION
## Summary
- rename `utils.sh` to `util.sh`
- move logging helpers and BYPASS flag defaults into `util.sh`
- source `util.sh` from the other scripts
- simplify scripts by removing duplicated helpers
- document the new helper script name

## Testing
- `bash -n util.sh`
- `bash -n install.sh`
- `bash -n update.sh`
- `bash -n cleanup.sh`
- `bash -n shell/zshrc_linux`


------
https://chatgpt.com/codex/tasks/task_e_6854d843136083248a918a8f1c57d18a