### PR TITLE
Fix conditional command checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -266,9 +266,13 @@ verify_essentials() {
     check_command git
     check_command zsh
     check_command curl
-    check_command cargo
+    if ! $BYPASS_CARGO; then
+        check_command cargo
+    fi
     [ "$OS" = "macos" ] && check_command brew
-    [ "$OS" = "linux" ] && check_command flatpak
+    if [ "$OS" = "linux" ] && ! $BYPASS_OS_PACKAGES; then
+        check_command flatpak
+    fi
 
     ZSH_PATH=$(command -v zsh)
     if [ "$SHELL" != "$ZSH_PATH" ]; then


### PR DESCRIPTION
## Summary
- only require `cargo` when BYPASS_CARGO is false
- check for `flatpak` only when OS package installation isn't bypassed

## Testing
- `shellcheck install.sh util.sh cleanup.sh update.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855a931f8948324a9eb8da5ca9158e2